### PR TITLE
fix: user state using conversation context

### DIFF
--- a/tutorials/python/Console-EchoBot/main.py
+++ b/tutorials/python/Console-EchoBot/main.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 import asyncio
-from botbuilder.core import TurnContext, ConversationState, UserState, MemoryStorage
+from botbuilder.core import TurnContext, ConversationState, MemoryStorage
 from botbuilder.schema import ActivityTypes
 
 from adapter import ConsoleAdapter


### PR DESCRIPTION
The user state seems to be reading the conversation context and not the user state context. It's a bug in the BF python. I'll open an issue on their repo to fix this. Currently removing user state references

closes #28 